### PR TITLE
Don't use tmpdir when writing files

### DIFF
--- a/src/SeatbeltFile.ts
+++ b/src/SeatbeltFile.ts
@@ -336,14 +336,8 @@ export class SeatbeltFile {
   writeSync() {
     const dataString = this.toDataString()
     const dir = nodePath.dirname(this.filename)
-    const base = nodePath.basename(this.filename)
-    const tempFile = nodePath.join(
-      os.tmpdir(),
-      `.${base}.wip${process.pid}.${Date.now()}.tmp`,
-    )
     fs.mkdirSync(dir, { recursive: true })
-    fs.writeFileSync(tempFile, dataString, "utf8")
-    fs.renameSync(tempFile, this.filename)
+    fs.writeFileSync(this.filename, dataString, "utf8")
   }
 
   toJSON(): SeatbeltFileJson {


### PR DESCRIPTION
This fixes https://github.com/justjake/eslint-seatbelt/issues/7 in a trivial way

NOTE: I don't know the context about why we need the tmpdir gym in the first place, there's probably a good reason... 

But this fixes the issue on my codebase