### PR TITLE
Fix EXDEV: cross-device link not permitted

### DIFF
--- a/src/SeatbeltFile.ts
+++ b/src/SeatbeltFile.ts
@@ -343,7 +343,8 @@ export class SeatbeltFile {
     )
     fs.mkdirSync(dir, { recursive: true })
     fs.writeFileSync(tempFile, dataString, "utf8")
-    fs.renameSync(tempFile, this.filename)
+    fs.copyFileSync(tempFile, this.filename)
+    fs.unlinkSync(tempFile)
   }
 
   toJSON(): SeatbeltFileJson {


### PR DESCRIPTION
Fixes #7. I found #8 after I'd created this one, but it hasn't been updated in a while, so I thought I'd go ahead and submit it anyway. I think using the env is the better way because those scenarios where the os tmp folder isn't enough are rare, and it's better to keep temporary junk there. It's probably best to delete the local temporary directory afterwards, but I think it would be okay just to add it to the `.gitignore`.

**UPD.:** I used simple copying instead of renaming, as suggested by @scriptin. This gets rid of the "EXDEV: cross-device link not permitted" problem.