### PR TITLE
Convert file paths used to POSIX

### DIFF
--- a/src/SeatbeltFile.test.ts
+++ b/src/SeatbeltFile.test.ts
@@ -131,4 +131,15 @@ describe("SeatbeltFile", () => {
     const roundtrippedFile = SeatbeltFile.fromJSON(json)
     assert.deepStrictEqual(roundtrippedFile.toJSON(), json)
   })
+
+  test("converts Windows backslashes to forward slashes", () => {
+    const windowsPath = "C:\\Users\\test\\Desktop\\eslint-seatbelt\\src\\SeatbeltFile.ts"
+    const expected = "C:/Users/test/Desktop/eslint-seatbelt/src/SeatbeltFile.ts"
+    assert.strictEqual(toPosixPath(windowsPath), expected)
+  })
+
+  test("preserves forward slashes in Unix paths", () => {
+    const unixPath = "/home/test/Desktop/eslint-seatbelt/src/SeatbeltFile.ts"
+    assert.strictEqual(toPosixPath(unixPath), unixPath)
+  })
 })


### PR DESCRIPTION
When running lint increase on windows the plugin did not recognize already existing files in the seatbelt file due to file path differences (`\\` vs `/`) so I converted all file paths used to POSIX path format for OS agnostic functionality especially in teams with multiple OSs used.

Issue resolved: https://github.com/justjake/eslint-seatbelt/issues/10