### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
@@ -34,4 +34,4 @@ jobs:
 
       - run: pnpm test
 
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Upgrade Node.js 22 → 24 (npm trusted publishing via OIDC requires npm ≥ 11.5.1)
- Re-add `--provenance` flag needed for OIDC authentication

## Test plan
- [ ] Merge and create a new release to verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)