### PR TITLE
Finish threadsafe implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,6 @@ This project uses `pnpm` for package management.
 
 ### Improvement ideas
 
-- [ ] Finish SEATBELT_THREADSAFE implementation
 - [ ] Set SEATBELT_DISABLE=1 during git merge/rebase events
 - [ ] Add SEATBELT_DISABLE_IN_EDITOR config option
 - [ ] Integration tests

--- a/src/FileLock.test.ts
+++ b/src/FileLock.test.ts
@@ -1,0 +1,116 @@
+import { test, describe } from "node:test"
+import assert from "node:assert"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { execFileSync } from "node:child_process"
+import { FileLock } from "./FileLock"
+
+function tmpLockPath(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `seatbelt-filelock-${label}-`))
+  return path.join(dir, "lock")
+}
+
+function findDeadPid(): number {
+  for (const candidate of [2_147_483_646, 999_999_998, 999_999_997]) {
+    try {
+      process.kill(candidate, 0)
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ESRCH") {
+        return candidate
+      }
+    }
+  }
+  throw new Error("could not find a non-existent pid for test setup")
+}
+
+describe("FileLock", () => {
+  test("tryLock returns true once and false on re-entry", () => {
+    const lockPath = tmpLockPath("re-entry")
+    const lock = new FileLock(lockPath)
+    try {
+      assert.strictEqual(lock.tryLock(), true)
+      assert.throws(
+        () => lock.tryLock(),
+        /already locked by this process/,
+      )
+    } finally {
+      lock.unlock()
+    }
+  })
+
+  test("two FileLock instances on the same path: first wins, second fails tryLock", () => {
+    const lockPath = tmpLockPath("contention")
+    const a = new FileLock(lockPath)
+    const b = new FileLock(lockPath)
+    try {
+      assert.strictEqual(a.tryLock(), true)
+      assert.strictEqual(b.tryLock(), false)
+    } finally {
+      a.unlock()
+    }
+  })
+
+  test("waitLock throws when lock is held by another instance past timeout", () => {
+    const lockPath = tmpLockPath("timeout")
+    const holder = new FileLock(lockPath)
+    const waiter = new FileLock(lockPath)
+    try {
+      assert.strictEqual(holder.tryLock(), true)
+      assert.throws(
+        () => waiter.waitLock(50),
+        /Timed out waiting for lock/,
+      )
+    } finally {
+      holder.unlock()
+    }
+  })
+
+  test("waitLock reclaims a stale lock whose pid is not alive", () => {
+    const lockPath = tmpLockPath("stale-pid")
+    const deadPid = findDeadPid()
+    fs.writeFileSync(lockPath, `${deadPid}\n`)
+
+    const lock = new FileLock(lockPath)
+    try {
+      lock.waitLock(200)
+      assert.strictEqual(lock.isLocked(), true)
+    } finally {
+      lock.unlock()
+    }
+  })
+
+  test("waitLock reclaims a lock left behind by a crashed child process", () => {
+    const lockPath = tmpLockPath("crashed-child")
+
+    const script = `
+      const { FileLock } = require(${JSON.stringify(path.resolve(__dirname, "FileLock"))});
+      const lock = new FileLock(process.argv[1]);
+      if (!lock.tryLock()) {
+        console.error("child: failed to acquire lock");
+        process.exit(2);
+      }
+      process.exit(0);
+    `
+
+    execFileSync(
+      process.execPath,
+      ["--require", "tsx/cjs", "-e", script, "--", lockPath],
+      { stdio: "pipe" },
+    )
+
+    assert.strictEqual(
+      fs.existsSync(lockPath),
+      true,
+      "precondition: child should have left the lock file behind",
+    )
+
+    const lock = new FileLock(lockPath)
+    try {
+      lock.waitLock(500)
+      assert.strictEqual(lock.isLocked(), true)
+    } finally {
+      lock.unlock()
+    }
+  })
+})

--- a/src/FileLock.test.ts
+++ b/src/FileLock.test.ts
@@ -83,6 +83,8 @@ describe("FileLock", () => {
   test("waitLock reclaims a lock left behind by a crashed child process", () => {
     const lockPath = tmpLockPath("crashed-child")
 
+    // SIGKILL so our exit/signal cleanup hooks can't run; the child leaves the
+    // lock file behind exactly like a real crash would.
     const script = `
       const { FileLock } = require(${JSON.stringify(path.resolve(__dirname, "FileLock"))});
       const lock = new FileLock(process.argv[1]);
@@ -90,14 +92,18 @@ describe("FileLock", () => {
         console.error("child: failed to acquire lock");
         process.exit(2);
       }
-      process.exit(0);
+      process.kill(process.pid, "SIGKILL");
     `
 
-    execFileSync(
-      process.execPath,
-      ["--require", "tsx/cjs", "-e", script, "--", lockPath],
-      { stdio: "pipe" },
-    )
+    try {
+      execFileSync(
+        process.execPath,
+        ["--require", "tsx/cjs", "-e", script, "--", lockPath],
+        { stdio: "pipe" },
+      )
+    } catch {
+      // Expected: SIGKILL gives a non-zero exit status.
+    }
 
     assert.strictEqual(
       fs.existsSync(lockPath),

--- a/src/FileLock.ts
+++ b/src/FileLock.ts
@@ -1,8 +1,41 @@
-import { openSync, writeSync, closeSync, constants, rmSync } from "node:fs"
+import {
+  openSync,
+  writeSync,
+  closeSync,
+  readFileSync,
+  constants,
+  rmSync,
+} from "node:fs"
 import { isErrno } from "./errorHanding"
 const { O_CREAT, O_EXCL, O_RDWR } = constants
 
 const waitBuffer = new Int32Array(new SharedArrayBuffer(4))
+
+const heldLocks = new Set<FileLock>()
+let cleanupHooksInstalled = false
+
+function installCleanupHooks() {
+  if (cleanupHooksInstalled) return
+  cleanupHooksInstalled = true
+
+  const release = () => {
+    for (const lock of heldLocks) {
+      try {
+        lock.unlock()
+      } catch {
+        // Best-effort; we're on our way out anyway.
+      }
+    }
+  }
+
+  process.on("exit", release)
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.on(signal, () => {
+      release()
+      process.exit(128 + (signal === "SIGINT" ? 2 : signal === "SIGTERM" ? 15 : 1))
+    })
+  }
+}
 
 /** Uses posix open(2) O_EXCL to implement a multi-process mutual exclusion lock. */
 export class FileLock {
@@ -13,6 +46,9 @@ export class FileLock {
     this.assertNotLocked()
     try {
       this.fd = openSync(this.filename, O_CREAT | O_EXCL | O_RDWR)
+      writeSync(this.fd, `${process.pid}\n`)
+      heldLocks.add(this)
+      installCleanupHooks()
       return true
     } catch (e) {
       if (isErrno(e, "EEXIST")) {
@@ -24,9 +60,16 @@ export class FileLock {
 
   waitLock(timeoutMs: number) {
     const deadline = Date.now() + timeoutMs
+    let attemptedRecovery = false
     while (!this.tryLock()) {
       if (Date.now() > deadline) {
-        throw new Error(`Timed out waiting for lock on ${this.filename}`)
+        if (!attemptedRecovery && this.reclaimIfStale()) {
+          attemptedRecovery = true
+          continue
+        }
+        throw new Error(
+          `Timed out waiting for lock on ${this.filename} after ${timeoutMs}ms`,
+        )
       }
       Atomics.wait(waitBuffer, 0, 0, 1)
     }
@@ -39,8 +82,13 @@ export class FileLock {
   unlock() {
     if (this.fd !== undefined) {
       closeSync(this.fd)
-      rmSync(this.filename)
+      try {
+        rmSync(this.filename)
+      } catch (e) {
+        if (!isErrno(e, "ENOENT")) throw e
+      }
       this.fd = undefined
+      heldLocks.delete(this)
     }
   }
 
@@ -50,5 +98,34 @@ export class FileLock {
         `FileLock "${this.filename}" is already locked by this process [pid ${process.pid}]`,
       )
     }
+  }
+
+  /**
+   * If the lock file exists but its recorded pid is no longer alive, remove it
+   * so a subsequent tryLock can succeed. Returns true if a stale file was
+   * removed.
+   */
+  private reclaimIfStale(): boolean {
+    let contents: string
+    try {
+      contents = readFileSync(this.filename, "utf8")
+    } catch (e) {
+      if (isErrno(e, "ENOENT")) return true
+      throw e
+    }
+    const pid = Number.parseInt(contents.trim(), 10)
+    if (!Number.isFinite(pid) || pid <= 0) return false
+    try {
+      process.kill(pid, 0)
+      return false
+    } catch (e) {
+      if (!isErrno(e, "ESRCH")) throw e
+    }
+    try {
+      rmSync(this.filename)
+    } catch (e) {
+      if (!isErrno(e, "ENOENT")) throw e
+    }
+    return true
   }
 }

--- a/src/FileLock.ts
+++ b/src/FileLock.ts
@@ -1,11 +1,4 @@
-import {
-  openSync,
-  writeSync,
-  closeSync,
-  readFileSync,
-  constants,
-  rmSync,
-} from "node:fs"
+import { openSync, writeSync, closeSync, readFileSync, constants, rmSync } from "node:fs"
 import { isErrno } from "./errorHanding"
 const { O_CREAT, O_EXCL, O_RDWR } = constants
 
@@ -13,6 +6,8 @@ const waitBuffer = new Int32Array(new SharedArrayBuffer(4))
 
 const heldLocks = new Set<FileLock>()
 let cleanupHooksInstalled = false
+
+const SIGNAL_EXIT_CODES = { SIGINT: 130, SIGTERM: 143, SIGHUP: 129 } as const
 
 function installCleanupHooks() {
   if (cleanupHooksInstalled) return
@@ -23,16 +18,16 @@ function installCleanupHooks() {
       try {
         lock.unlock()
       } catch {
-        // Best-effort; we're on our way out anyway.
+        // On our way out; can't do much about it.
       }
     }
   }
 
   process.on("exit", release)
-  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+  for (const signal of Object.keys(SIGNAL_EXIT_CODES) as (keyof typeof SIGNAL_EXIT_CODES)[]) {
     process.on(signal, () => {
       release()
-      process.exit(128 + (signal === "SIGINT" ? 2 : signal === "SIGTERM" ? 15 : 1))
+      process.exit(SIGNAL_EXIT_CODES[signal])
     })
   }
 }
@@ -67,9 +62,7 @@ export class FileLock {
           attemptedRecovery = true
           continue
         }
-        throw new Error(
-          `Timed out waiting for lock on ${this.filename} after ${timeoutMs}ms`,
-        )
+        throw new Error(`Timed out waiting for lock on ${this.filename}`)
       }
       Atomics.wait(waitBuffer, 0, 0, 1)
     }
@@ -100,11 +93,6 @@ export class FileLock {
     }
   }
 
-  /**
-   * If the lock file exists but its recorded pid is no longer alive, remove it
-   * so a subsequent tryLock can succeed. Returns true if a stale file was
-   * removed.
-   */
   private reclaimIfStale(): boolean {
     let contents: string
     try {

--- a/src/SeatbeltConfig.test.ts
+++ b/src/SeatbeltConfig.test.ts
@@ -1,5 +1,7 @@
 import { test, describe } from "node:test"
 import assert from "node:assert"
+import * as path from "node:path"
+import { Worker } from "node:worker_threads"
 import {
   SeatbeltConfig,
   SeatbeltArgs,
@@ -35,4 +37,32 @@ describe("SeatbeltConfig", () => {
     const args = SeatbeltArgs.fromConfig({ quiet: true })
     assert.strictEqual(args.quiet, true)
   })
+
+  test("fromFallbackEnv() leaves threadsafe undefined on the main thread", () => {
+    const config = SeatbeltConfig.fromFallbackEnv({})
+    assert.strictEqual(config.threadsafe, undefined)
+  })
+
+  test("fromFallbackEnv() defaults threadsafe to true inside a worker_thread", async () => {
+    const threadsafe = await runInWorker<boolean | undefined>(`
+      const { SeatbeltConfig } = require(${JSON.stringify(path.resolve(__dirname, "SeatbeltConfig"))});
+      const config = SeatbeltConfig.fromFallbackEnv({});
+      require("node:worker_threads").parentPort.postMessage(config.threadsafe);
+    `)
+    assert.strictEqual(threadsafe, true)
+  })
 })
+
+function runInWorker<T>(script: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(script, {
+      eval: true,
+      execArgv: ["--require", "tsx/cjs"],
+    })
+    worker.once("message", (value: T) => {
+      resolve(value)
+      worker.terminate()
+    })
+    worker.once("error", reject)
+  })
+}

--- a/src/SeatbeltConfig.ts
+++ b/src/SeatbeltConfig.ts
@@ -401,9 +401,7 @@ export const SeatbeltConfig = {
         true,
       )
     }
-    // ESLint --concurrency (v9.34+) and any custom worker-based runner lint in
-    // parallel inside Node worker_threads of the same process. Separate V8
-    // isolates -> separate module caches -> racing SeatbeltFile writes.
+    // ESLint --concurrency (v9.34+) lint in parallel inside Node worker_threads of the same process
     if (!isMainThread) {
       config.threadsafe = true
       log?.(
@@ -429,7 +427,9 @@ export const SeatbeltConfig = {
     }
     const seatbeltFile = env[SEATBELT_FILE]
     if (seatbeltFile) {
-      const rootRelative = path.isAbsolute(seatbeltFile) ? seatbeltFile : path.join(config.pwd, seatbeltFile)
+      const rootRelative = path.isAbsolute(seatbeltFile)
+        ? seatbeltFile
+        : path.join(config.pwd, seatbeltFile)
       config.seatbeltFile = rootRelative
       log?.(`${padVarName(SEATBELT_FILE)} config.seatbeltFile =`, rootRelative)
     }

--- a/src/SeatbeltConfig.ts
+++ b/src/SeatbeltConfig.ts
@@ -304,7 +304,8 @@ export interface SeatbeltConfig {
    * When enabled, seatbelt creates temporary lock files to serialize updates to
    * the seatbelt file. This comes at a small performance cost.
    *
-   * This is enabled by default when run with Jest (environment variable `JEST_WORKER_ID` is set).
+   * This is enabled by default when run with Jest (environment variable `JEST_WORKER_ID` is set)
+   * or inside a Node `worker_threads` worker (e.g. ESLint `--concurrency`).
    *
    * It can also be set with environment variable `SEATBELT_THREADSAFE`:
    *

--- a/src/SeatbeltConfig.ts
+++ b/src/SeatbeltConfig.ts
@@ -1,6 +1,7 @@
 import type { RuleId } from "./SeatbeltFile"
 import { name } from "../package.json"
 import path from "node:path"
+import { isMainThread } from "node:worker_threads"
 import { findRepoRoot } from "./repoIntegration"
 
 export const SEATBELT_FILE_NAME = "eslint.seatbelt.tsv"
@@ -397,6 +398,16 @@ export const SeatbeltConfig = {
       config.threadsafe = true
       log?.(
         `${padVarName("JEST_WORKER_ID")} config.threadsafe defaults to`,
+        true,
+      )
+    }
+    // ESLint --concurrency (v9.34+) and any custom worker-based runner lint in
+    // parallel inside Node worker_threads of the same process. Separate V8
+    // isolates -> separate module caches -> racing SeatbeltFile writes.
+    if (!isMainThread) {
+      config.threadsafe = true
+      log?.(
+        `${padVarName("worker_threads")} config.threadsafe defaults to`,
         true,
       )
     }

--- a/src/SeatbeltFile.test.ts
+++ b/src/SeatbeltFile.test.ts
@@ -146,10 +146,6 @@ describe("SeatbeltFile", () => {
     const seatbeltFilename = path.join(tmpDir, "eslint.seatbelt.tsv")
     const existingSrc = path.join(tmpDir, "existing.ts")
     fs.writeFileSync(existingSrc, "")
-    // Seed two entries: existing.ts (file present on disk) and gone.ts (file
-    // missing). The staler's cleanup will want to drop gone.ts, forcing it
-    // down the write path where a stale in-memory existing.ts count could
-    // clobber the writer's update.
     fs.writeFileSync(
       seatbeltFilename,
       [
@@ -172,13 +168,9 @@ describe("SeatbeltFile", () => {
 
     const staler = SeatbeltFile.openSync(seatbeltFilename)
 
-    // Writer simulates a concurrent process landing an update to disk.
     const writer = SeatbeltFile.openSync(seatbeltFilename)
     writer.updateFileMaxErrors(args, existingSrc, new Map([["rule1", 5]]))
 
-    // Now staler runs cleanup. It must drop gone.ts, but under threadsafe it
-    // also has to re-read under the lock so existing.ts's fresh {rule1: 5}
-    // round-trips through its write.
     const { removedFiles } = staler.cleanUpRemovedFiles(args)
     assert.strictEqual(removedFiles, 1)
 

--- a/src/SeatbeltFile.test.ts
+++ b/src/SeatbeltFile.test.ts
@@ -100,6 +100,87 @@ describe("SeatbeltFile", () => {
     await fs.promises.rm(tmpDir, { recursive: true })
   })
 
+  test("cleanUpRemovedFiles removes entries whose source file is gone", async () => {
+    const tmpDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "seatbelt-cleanup-"),
+    )
+    const seatbeltFilename = path.join(tmpDir, "eslint.seatbelt.tsv")
+    const existingSrc = path.join(tmpDir, "existing.ts")
+    const goneSrc = path.join(tmpDir, "gone.ts")
+    fs.writeFileSync(existingSrc, "")
+    fs.writeFileSync(
+      seatbeltFilename,
+      [
+        `${JSON.stringify("existing.ts")}\t${JSON.stringify("rule1")}\t1\n`,
+        `${JSON.stringify("gone.ts")}\t${JSON.stringify("rule1")}\t2\n`,
+      ].join(""),
+    )
+
+    const args: SeatbeltArgs = {
+      root: tmpDir,
+      seatbeltFile: seatbeltFilename,
+      keepRules: new Set(),
+      allowIncreaseRules: new Set(),
+      frozen: false,
+      disable: false,
+      quiet: false,
+      threadsafe: false,
+      verbose: false,
+    }
+
+    const file = SeatbeltFile.openSync(seatbeltFilename)
+    const { removedFiles } = file.cleanUpRemovedFiles(args)
+
+    assert.strictEqual(removedFiles, 1)
+    const reread = SeatbeltFile.readSync(seatbeltFilename)
+    assert.ok(reread.getMaxErrors(existingSrc))
+    assert.strictEqual(reread.getMaxErrors(goneSrc), undefined)
+
+    await fs.promises.rm(tmpDir, { recursive: true })
+  })
+
+  test("threadsafe cleanUpRemovedFiles does not clobber a concurrent update on stale in-memory state", async () => {
+    const tmpDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "seatbelt-cleanup-race-"),
+    )
+    const seatbeltFilename = path.join(tmpDir, "eslint.seatbelt.tsv")
+    const existingSrc = path.join(tmpDir, "existing.ts")
+    fs.writeFileSync(existingSrc, "")
+    fs.writeFileSync(
+      seatbeltFilename,
+      `${JSON.stringify("existing.ts")}\t${JSON.stringify("rule1")}\t1\n`,
+    )
+
+    const args: SeatbeltArgs = {
+      root: tmpDir,
+      seatbeltFile: seatbeltFilename,
+      keepRules: new Set(),
+      allowIncreaseRules: "all",
+      frozen: false,
+      disable: false,
+      quiet: false,
+      threadsafe: true,
+      verbose: false,
+    }
+
+    // Staler: opens the file and then sits on stale in-memory state.
+    const staler = SeatbeltFile.openSync(seatbeltFilename)
+
+    // Writer: simulates a concurrent process landing an update to disk.
+    const writer = SeatbeltFile.openSync(seatbeltFilename)
+    writer.updateFileMaxErrors(args, existingSrc, new Map([["rule1", 5]]))
+
+    // Now staler runs cleanup. existing.ts is still present, so nothing should
+    // be removed; but without locking + fresh read, staler would rewrite its
+    // stale {rule1: 1} over the writer's {rule1: 5}.
+    staler.cleanUpRemovedFiles(args)
+
+    const final = SeatbeltFile.readSync(seatbeltFilename)
+    assert.strictEqual(final.getMaxErrors(existingSrc)?.get("rule1"), 5)
+
+    await fs.promises.rm(tmpDir, { recursive: true })
+  })
+
   test("toJSON() and fromJSON() roundtrip", () => {
     const file = SeatbeltFile.fromJSON({
       filename: "/test/eslint.seatbelt.tsv",

--- a/src/SeatbeltFile.test.ts
+++ b/src/SeatbeltFile.test.ts
@@ -146,9 +146,16 @@ describe("SeatbeltFile", () => {
     const seatbeltFilename = path.join(tmpDir, "eslint.seatbelt.tsv")
     const existingSrc = path.join(tmpDir, "existing.ts")
     fs.writeFileSync(existingSrc, "")
+    // Seed two entries: existing.ts (file present on disk) and gone.ts (file
+    // missing). The staler's cleanup will want to drop gone.ts, forcing it
+    // down the write path where a stale in-memory existing.ts count could
+    // clobber the writer's update.
     fs.writeFileSync(
       seatbeltFilename,
-      `${JSON.stringify("existing.ts")}\t${JSON.stringify("rule1")}\t1\n`,
+      [
+        `${JSON.stringify("existing.ts")}\t${JSON.stringify("rule1")}\t1\n`,
+        `${JSON.stringify("gone.ts")}\t${JSON.stringify("rule1")}\t1\n`,
+      ].join(""),
     )
 
     const args: SeatbeltArgs = {
@@ -163,20 +170,21 @@ describe("SeatbeltFile", () => {
       verbose: false,
     }
 
-    // Staler: opens the file and then sits on stale in-memory state.
     const staler = SeatbeltFile.openSync(seatbeltFilename)
 
-    // Writer: simulates a concurrent process landing an update to disk.
+    // Writer simulates a concurrent process landing an update to disk.
     const writer = SeatbeltFile.openSync(seatbeltFilename)
     writer.updateFileMaxErrors(args, existingSrc, new Map([["rule1", 5]]))
 
-    // Now staler runs cleanup. existing.ts is still present, so nothing should
-    // be removed; but without locking + fresh read, staler would rewrite its
-    // stale {rule1: 1} over the writer's {rule1: 5}.
-    staler.cleanUpRemovedFiles(args)
+    // Now staler runs cleanup. It must drop gone.ts, but under threadsafe it
+    // also has to re-read under the lock so existing.ts's fresh {rule1: 5}
+    // round-trips through its write.
+    const { removedFiles } = staler.cleanUpRemovedFiles(args)
+    assert.strictEqual(removedFiles, 1)
 
     const final = SeatbeltFile.readSync(seatbeltFilename)
     assert.strictEqual(final.getMaxErrors(existingSrc)?.get("rule1"), 5)
+    assert.strictEqual(final.getMaxErrors(path.join(tmpDir, "gone.ts")), undefined)
 
     await fs.promises.rm(tmpDir, { recursive: true })
   })

--- a/src/SeatbeltFile.ts
+++ b/src/SeatbeltFile.ts
@@ -290,6 +290,25 @@ export class SeatbeltFile {
     return { removedRules, increasedRulesCount, decreasedRulesCount }
   }
 
+  /** Atomic read -> apply delta -> write. Takes an exclusive file lock when `args.threadsafe`. */
+  updateFileMaxErrors(
+    args: SeatbeltArgs,
+    filename: SourceFileName,
+    ruleToErrorCount: ReadonlyMap<RuleId, number>,
+  ): {
+    ruleToMaxErrorCountBefore: ReadonlyMap<RuleId, number> | undefined
+    removedRules: Set<RuleId>
+    increasedRulesCount: number
+    decreasedRulesCount: number
+  } {
+    // TODO(threadsafe): read-latest-under-lock, merge the delta in
+    // `ruleToErrorCount`, flushChanges, release.
+    void args
+    void filename
+    void ruleToErrorCount
+    throw new Error("SeatbeltFile.updateFileMaxErrors not implemented")
+  }
+
   toDataString(): string {
     const lines: string[] = []
     this.data.forEach((fileState, filename) => {

--- a/src/SeatbeltFile.ts
+++ b/src/SeatbeltFile.ts
@@ -315,10 +315,7 @@ export class SeatbeltFile {
     })
   }
 
-  /**
-   * Drop any entries whose source file no longer exists on disk. Takes an
-   * exclusive file lock when `args.threadsafe`.
-   */
+  /** Drop entries whose source file no longer exists. Takes an exclusive file lock when `args.threadsafe`. */
   cleanUpRemovedFiles(args: SeatbeltArgs): { removedFiles: number } {
     return this.withOptionalLock(args, () => {
       let removedFiles = 0

--- a/src/SeatbeltFile.ts
+++ b/src/SeatbeltFile.ts
@@ -320,8 +320,20 @@ export class SeatbeltFile {
    * exclusive file lock when `args.threadsafe`.
    */
   cleanUpRemovedFiles(args: SeatbeltArgs): { removedFiles: number } {
-    void args
-    throw new Error("SeatbeltFile.cleanUpRemovedFiles not implemented")
+    return this.withOptionalLock(args, () => {
+      let removedFiles = 0
+      for (const filename of Array.from(this.filenames())) {
+        if (!fs.existsSync(filename)) {
+          if (this.removeFile(filename, args)) {
+            removedFiles++
+          }
+        }
+      }
+      if (!args.frozen) {
+        this.flushChanges()
+      }
+      return { removedFiles }
+    })
   }
 
   private withOptionalLock<T>(args: SeatbeltArgs, fn: () => T): T {

--- a/src/SeatbeltFile.ts
+++ b/src/SeatbeltFile.ts
@@ -10,6 +10,9 @@ import {
 } from "./SeatbeltConfig"
 import { name } from "../package.json"
 import { appendErrorContext, isErrno } from "./errorHanding"
+import { FileLock } from "./FileLock"
+
+const LOCK_TIMEOUT_MS = 30_000
 
 export type SourceFileName = string
 export type RuleId = string
@@ -301,12 +304,29 @@ export class SeatbeltFile {
     increasedRulesCount: number
     decreasedRulesCount: number
   } {
-    // TODO(threadsafe): read-latest-under-lock, merge the delta in
-    // `ruleToErrorCount`, flushChanges, release.
-    void args
-    void filename
-    void ruleToErrorCount
-    throw new Error("SeatbeltFile.updateFileMaxErrors not implemented")
+    return this.withOptionalLock(args, () => {
+      const before = this.getMaxErrors(filename)
+      const ruleToMaxErrorCountBefore = before ? new Map(before) : undefined
+      const result = this.updateMaxErrors(filename, args, ruleToErrorCount)
+      if (!args.frozen) {
+        this.flushChanges()
+      }
+      return { ruleToMaxErrorCountBefore, ...result }
+    })
+  }
+
+  private withOptionalLock<T>(args: SeatbeltArgs, fn: () => T): T {
+    if (!args.threadsafe) {
+      return fn()
+    }
+    const lock = new FileLock(`${this.filename}.lock`)
+    lock.waitLock(LOCK_TIMEOUT_MS)
+    try {
+      this.readSync()
+      return fn()
+    } finally {
+      lock.unlock()
+    }
   }
 
   toDataString(): string {

--- a/src/SeatbeltFile.ts
+++ b/src/SeatbeltFile.ts
@@ -315,6 +315,15 @@ export class SeatbeltFile {
     })
   }
 
+  /**
+   * Drop any entries whose source file no longer exists on disk. Takes an
+   * exclusive file lock when `args.threadsafe`.
+   */
+  cleanUpRemovedFiles(args: SeatbeltArgs): { removedFiles: number } {
+    void args
+    throw new Error("SeatbeltFile.cleanUpRemovedFiles not implemented")
+  }
+
   private withOptionalLock<T>(args: SeatbeltArgs, fn: () => T): T {
     if (!args.threadsafe) {
       return fn()

--- a/src/SeatbeltProcessor.concurrent.test.ts
+++ b/src/SeatbeltProcessor.concurrent.test.ts
@@ -1,0 +1,75 @@
+import { test, describe } from "node:test"
+import assert from "node:assert"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { Worker } from "node:worker_threads"
+import { SeatbeltFile } from "./SeatbeltFile"
+
+const WORKER_PATH = path.resolve(
+  __dirname,
+  "SeatbeltProcessor.concurrent.worker.ts",
+)
+
+const ITERATIONS = 20
+const WORKER_COUNT = 8
+
+describe("SeatbeltProcessor concurrency", () => {
+  test(
+    `threadsafe worker_threads writes never lose updates (N=${WORKER_COUNT}, ${ITERATIONS} iterations)`,
+    async () => {
+      for (let iter = 0; iter < ITERATIONS; iter++) {
+        const dir = fs.mkdtempSync(
+          path.join(os.tmpdir(), `seatbelt-concurrent-${iter}-`),
+        )
+        const seatbeltFilename = path.join(dir, "eslint.seatbelt.tsv")
+        fs.writeFileSync(seatbeltFilename, "")
+
+        const sab = new SharedArrayBuffer(4)
+        const barrier = new Int32Array(sab)
+
+        const workers = Array.from(
+          { length: WORKER_COUNT },
+          (_, index) =>
+            new Worker(WORKER_PATH, {
+              workerData: { seatbeltFile: seatbeltFilename, index, sab },
+              execArgv: ["--require", "tsx/cjs"],
+            }),
+        )
+
+        // Give workers time to reach Atomics.wait; then release them all at once.
+        await new Promise((resolve) => setTimeout(resolve, 75))
+        Atomics.store(barrier, 0, 1)
+        Atomics.notify(barrier, 0, WORKER_COUNT)
+
+        await Promise.all(
+          workers.map(
+            (worker) =>
+              new Promise<void>((resolve, reject) => {
+                worker.once("error", reject)
+                worker.once("exit", (code) =>
+                  code === 0
+                    ? resolve()
+                    : reject(new Error(`worker exited with code ${code}`)),
+                )
+              }),
+          ),
+        )
+
+        const file = SeatbeltFile.readSync(seatbeltFilename)
+        const got = Array.from(file.filenames())
+          .map((f) => path.basename(f))
+          .sort()
+        const want = Array.from(
+          { length: WORKER_COUNT },
+          (_, i) => `file${i}.ts`,
+        ).sort()
+        assert.deepStrictEqual(
+          got,
+          want,
+          `iteration ${iter}: expected every worker's update to be present in the seatbelt file`,
+        )
+      }
+    },
+  )
+})

--- a/src/SeatbeltProcessor.concurrent.worker.ts
+++ b/src/SeatbeltProcessor.concurrent.worker.ts
@@ -23,7 +23,7 @@ const args: SeatbeltArgs = {
   root: "/",
   seatbeltFile,
   keepRules: new Set(),
-  allowIncreaseRules: new Set(),
+  allowIncreaseRules: "all",
   frozen: false,
   disable: false,
   quiet: false,

--- a/src/SeatbeltProcessor.concurrent.worker.ts
+++ b/src/SeatbeltProcessor.concurrent.worker.ts
@@ -1,0 +1,39 @@
+// Worker entry point for SeatbeltProcessor.concurrent.test.ts.
+// `new Worker(path, ...)` needs a script file - can't be inlined in the test.
+
+import { workerData } from "node:worker_threads"
+import { SeatbeltFile } from "./SeatbeltFile"
+import type { SeatbeltArgs } from "./SeatbeltConfig"
+
+interface ConcurrentWorkerData {
+  seatbeltFile: string
+  index: number
+  sab: SharedArrayBuffer
+}
+
+const { seatbeltFile, index, sab } = workerData as ConcurrentWorkerData
+const barrier = new Int32Array(sab)
+
+// Sleep until the main thread stores a non-zero value at barrier[0] and
+// Atomics.notify-s this waiter. Ensures every worker enters the critical
+// section below simultaneously, not staggered by worker-startup latency.
+Atomics.wait(barrier, 0, 0)
+
+const args: SeatbeltArgs = {
+  root: "/",
+  seatbeltFile,
+  keepRules: new Set(),
+  allowIncreaseRules: new Set(),
+  frozen: false,
+  disable: false,
+  quiet: false,
+  threadsafe: true,
+  verbose: false,
+}
+
+const file = SeatbeltFile.openSync(seatbeltFile)
+file.updateFileMaxErrors(
+  args,
+  `file${index}.ts`,
+  new Map([[`rule${index}`, 1]]),
+)

--- a/src/SeatbeltProcessor.ts
+++ b/src/SeatbeltProcessor.ts
@@ -53,9 +53,8 @@ export const SeatbeltProcessor: Linter.Processor = {
     }
 
     const seatbeltFile = pluginGlobals.getSeatbeltFile(args.seatbeltFile)
-    // For non-CLI runs (e.g. editors, long-lived processes) refresh the cached
-    // in-memory copy so we don't miss on-disk edits since last lint. The
-    // threadsafe case is handled under lock inside updateFileMaxErrors.
+    // Refresh the cached copy for long-lived processes (editors).
+    // The threadsafe case re-reads under lock inside updateFileMaxErrors.
     if (!pluginGlobals.isEslintCli()) {
       seatbeltFile.readSync()
     }

--- a/src/SeatbeltProcessor.ts
+++ b/src/SeatbeltProcessor.ts
@@ -53,7 +53,10 @@ export const SeatbeltProcessor: Linter.Processor = {
     }
 
     const seatbeltFile = pluginGlobals.getSeatbeltFile(args.seatbeltFile)
-    if (args.threadsafe || !pluginGlobals.isEslintCli()) {
+    // For non-CLI runs (e.g. editors, long-lived processes) refresh the cached
+    // in-memory copy so we don't miss on-disk edits since last lint. The
+    // threadsafe case is handled under lock inside updateFileMaxErrors.
+    if (!pluginGlobals.isEslintCli()) {
       seatbeltFile.readSync()
     }
     const ruleToErrorCount = countRuleIds(messages)
@@ -257,25 +260,14 @@ function maybeWriteStateUpdate(
   if (args.disable) {
     return
   }
-  if (args.threadsafe) {
-    // TODO: Implement locking
-    // For now just refresh the file.
-    stateFile.readSync()
-  }
 
-  const ruleToMaxErrorCount = stateFile.getMaxErrors(filename)
-  const { removedRules } = stateFile.updateMaxErrors(
-    filename,
-    args,
-    ruleToErrorCount,
-  )
-  if (!args.frozen) {
-    stateFile.flushChanges()
-  } else if (removedRules && removedRules.size > 0) {
-    // We didn't actually update the state file in this case.
-    // We need to add an original error message about the inconsistent state.
+  const { ruleToMaxErrorCountBefore, removedRules } =
+    stateFile.updateFileMaxErrors(args, filename, ruleToErrorCount)
+
+  if (args.frozen && removedRules.size > 0) {
+    // State file wasn't updated. Surface the inconsistency as lint messages.
     return Array.from(removedRules).map((ruleId) => {
-      const maxErrorCount = ruleToMaxErrorCount?.get(ruleId)
+      const maxErrorCount = ruleToMaxErrorCountBefore?.get(ruleId)
       if (maxErrorCount === undefined) {
         throw new Error(
           `${name} bug: maxErrorCount not found for removed frozen rule ${ruleId}`,

--- a/src/pluginGlobals.ts
+++ b/src/pluginGlobals.ts
@@ -14,7 +14,6 @@ import {
 } from "./SeatbeltConfig"
 import { SeatbeltFile } from "./SeatbeltFile"
 import { name, version } from "../package.json"
-import fs from "node:fs"
 
 let ANY_CONFIG_DISABLED = false
 let LAST_VERBOSE_ARGS: SeatbeltArgs | undefined
@@ -252,15 +251,8 @@ function handleEslintCliExit(_runContext: RunContext) {
 function cleanUpRemovedFiles() {
   for (const args of CLI_ARGS) {
     const seatbeltFile = getSeatbeltFile(args.seatbeltFile)
-    // TODO: args.threadsafe
-    seatbeltFile.readSync()
-    for (const filename of seatbeltFile.filenames()) {
-      if (!fs.existsSync(filename)) {
-        seatbeltFile.removeFile(filename, args)
-        incrementStat("removedFiles")
-      }
-    }
-    seatbeltFile.writeSync()
+    const { removedFiles } = seatbeltFile.cleanUpRemovedFiles(args)
+    incrementStat("removedFiles", removedFiles)
   }
 }
 


### PR DESCRIPTION
## Summary

Finishes the `SEATBELT_THREADSAFE` TODO called out in the README. Under `args.threadsafe`, every read-modify-write on the seatbelt file now happens under an exclusive `FileLock`.

- **`FileLock`**: records the owning pid in the lockfile; reclaims stale locks when the recorded pid is no longer alive (`process.kill(pid, 0)` -> `ESRCH`); registers `exit`/`SIGINT`/`SIGTERM`/`SIGHUP` hooks that release all held locks so graceful shutdowns stop leaking lockfiles.
- **`SeatbeltFile.updateFileMaxErrors`** and **`SeatbeltFile.cleanUpRemovedFiles`**: new threadsafe-aware APIs. Inside the lock they re-`readSync` from disk so stale in-memory state can't clobber a concurrent writer. `SeatbeltProcessor` and `pluginGlobals.cleanUpRemovedFiles` both delegate to these now.
- **Auto-detection widened**: `threadsafe` defaults to `true` inside a `worker_threads` worker, not just when `JEST_WORKER_ID` is set. Covers ESLint `--concurrency` (v9.34+). Single-process main-thread runs stay opt-in.

## Test plan
Created automated tests, using strict test-driven-development.

Also tested this out on https://github.com/Expensify/App, where our lint times are significantly improved by `--concurrency=auto`. I ran into race conditions running concurrent lint w/ the eslint-seatbelt processer:

<details>
<summary>Error sample</summary>

```
'---EXIT---'
]633;C
ESLint: 9.36.0

Error: ENOENT: no such file or directory, rename '/var/folders/74/3_bjsyr103b45mdz_xm3gyq00000gn/T/.eslint.seatbelt.tsv.wip80091.1776906511136.tmp' -> '/Users/roryabraham/Expensidev/App/config/eslint/eslint.seatbelt.tsv'
  while processing `/Users/roryabraham/Expensidev/App/src/libs/actions/MergeTransaction.ts`
  this may be a bug in eslint-seatbelt@0.1.3 or a problem with your setup
    at Module.renameSync (node:fs:1032:11)
    at _SeatbeltFile.writeSync (file:///Users/roryabraham/Expensidev/App/node_modules/eslint-seatbelt/dist/chunk-OKIIDZIF.mjs:280:10)
    at _SeatbeltFile.flushChanges (file:///Users/roryabraham/Expensidev/App/node_modules/eslint-seatbelt/dist/chunk-OKIIDZIF.mjs:263:12)
    at maybeWriteStateUpdate (file:///Users/roryabraham/Expensidev/App/node_modules/eslint-seatbelt/dist/index.mjs:376:15)
    at Object.postprocess (file:///Users/roryabraham/Expensidev/App/node_modules/eslint-seatbelt/dist/index.mjs:230:36)
    at Object.postprocess (file:///Users/roryabraham/Expensidev/App/config/eslint/processors/eslint-processor-expensify.mjs:21:34)
    at ProcessorService.postprocessSync (/Users/roryabraham/Expensidev/App/node_modules/eslint/lib/services/processor-service.js:97:20)
    at Linter._verifyWithFlatConfigArrayAndProcessor (/Users/roryabraham/Expensidev/App/node_modules/eslint/lib/linter/linter.js:1816:27)
    at Linter._verifyWithFlatConfigArray (/Users/roryabraham/Expensidev/App/node_modules/eslint/lib/linter/linter.js:2275:16)
    at Linter.verify (/Users/roryabraham/Expensidev/App/node_modules/eslint/lib/linter/linter.js:1677:10)
    at Linter.verifyAndFix (/Users/roryabraham/Expensidev/App/node_modules/eslint/lib/linter/linter.js:2557:20)
    at verifyText (/Users/roryabraham/Expensidev/App/node_modules/eslint/lib/eslint/eslint-helpers.js:1179:45)
    at readAndVerifyFile (/Users/roryabraham/Expensidev/App/node_modules/eslint/lib/eslint/eslint-helpers.js:1320:10)
    at async /Users/roryabraham/Expensidev/App/node_modules/eslint/lib/eslint/worker.js:133:18
]633;D;2
```
</details>

I applied the changes on this branch using [patch-package](https://www.npmjs.com/package/patch-package), then ran our full concurrent lint 5 times (busting cache before each run), and it all seemed to work as expected. 🎉 